### PR TITLE
Feature/logger debug api

### DIFF
--- a/lib/battle_snake/api.ex
+++ b/lib/battle_snake/api.ex
@@ -34,17 +34,7 @@ defmodule BattleSnake.Api do
       )
       error ->
       (
-        http_response = inspect(api_response.raw_response, color: false, pretty: true)
-        ("""
-        Could not process API response for #{request_url}:
-
-        Poison JSON Parsing Error:
-        #{inspect error}
-
-        HTTPoison HTTP Response:
-        #{http_response}
-        """)
-        |> Logger.debug
+        log_error(request_url, error, api_response)
         error
       )
     end)
@@ -74,7 +64,25 @@ defmodule BattleSnake.Api do
         snake = struct(type, map)
         {:ok, snake}
       )
-      error -> error
+      error ->
+      (
+        log_error(url, error, api_response)
+        error
+      )
     end)
+  end
+
+  defp log_error(url, error, api_response) do
+    http_response = inspect(api_response.raw_response, color: false, pretty: true)
+    ("""
+    Could not process API response for #{url}:
+
+    Poison JSON Parsing Error:
+    #{inspect error}
+
+    HTTPoison HTTP Response:
+    #{http_response}
+    """)
+    |> Logger.debug
   end
 end

--- a/test/battle_snake/game_server/state_test.exs
+++ b/test/battle_snake/game_server/state_test.exs
@@ -1,5 +1,4 @@
 defmodule BattleSnake.GameServer.StateTest do
-  alias BattleSnake.GameServer
   alias BattleSnake.GameServer.State
 
   use BattleSnake.Case, async: false


### PR DESCRIPTION
Adds Logger debug level output for failed API requests.

closes #6.

Example log:


```elixir
[debug] Could not process API response for localhost:4001/start:

Poison JSON Parsing Error:
{:error, {:invalid, "<"}}

HTTPoison HTTP Response:
{:ok,
 %HTTPoison.Response{body: "<!DOCTYPE html>\n<html>\n<head>\n  <style type=\"text/css\">\n  body { text-align:center;font-family:helvetica,arial;font-size:22px;\n    color:#888;margin:20px}\n  #c {margin:0 auto;width:500px;text-align:left}\n  </style>\n</head>\n<body>\n  <h2>Sinatra doesn&rsquo;t know this ditty.</h2>\n  <img src='http://localhost:4001/__sinatra__/404.png'>\n  <div id=\"c\">\n    Try this:\n    <pre># in ruby_snake.rb\nclass RubySnake\n  post &#x27;&#x2F;start&#x27; do\n    &quot;Hello World&quot;\n  end\nend\n</pre>\n  </div>\n</body>\n</html>\n",
  headers: [{"Content-Type", "text/html;charset=utf-8"}, {"X-Cascade", "pass"},
   {"Content-Length", "513"}, {"X-Xss-Protection", "1; mode=block"},
   {"X-Content-Type-Options", "nosniff"}, {"X-Frame-Options", "SAMEORIGIN"},
   {"Server", "WEBrick/1.3.1 (Ruby/2.3.3/2016-11-21)"},
   {"Date", "Sun, 12 Feb 2017 05:47:40 GMT"}, {"Connection", "Keep-Alive"}],
  status_code: 404}}

[debug] Could not process API response for localhost:4001/move:

Poison JSON Parsing Error:
{:error, {:invalid, "<"}}

HTTPoison HTTP Response:
{:ok,
 %HTTPoison.Response{body: "<!DOCTYPE html>\n<html>\n<head>\n  <style type=\"text/css\">\n  body { text-align:center;font-family:helvetica,arial;font-size:22px;\n    color:#888;margin:20px}\n  #c {margin:0 auto;width:500px;text-align:left}\n  </style>\n</head>\n<body>\n  <h2>Sinatra doesn&rsquo;t know this ditty.</h2>\n  <img src='http://localhost:4001/__sinatra__/404.png'>\n  <div id=\"c\">\n    Try this:\n    <pre># in ruby_snake.rb\nclass RubySnake\n  post &#x27;&#x2F;move&#x27; do\n    &quot;Hello World&quot;\n  end\nend\n</pre>\n  </div>\n</body>\n</html>\n",
  headers: [{"Content-Type", "text/html;charset=utf-8"}, {"X-Cascade", "pass"},
   {"Content-Length", "512"}, {"X-Xss-Protection", "1; mode=block"},
   {"X-Content-Type-Options", "nosniff"}, {"X-Frame-Options", "SAMEORIGIN"},
   {"Server", "WEBrick/1.3.1 (Ruby/2.3.3/2016-11-21)"},
   {"Date", "Sun, 12 Feb 2017 05:47:40 GMT"}, {"Connection", "Keep-Alive"}],
  status_code: 404}}
```