### PR TITLE
Render game server after joining game

### DIFF
--- a/lib/battle_snake/game_server.ex
+++ b/lib/battle_snake/game_server.ex
@@ -18,6 +18,7 @@ defmodule BattleSnake.GameServer do
     GenServer.start_link(__MODULE__, args, opts)
   end
 
+  defdelegate get_game_state(pid), to: GameServer.Client
   defdelegate get_state(pid), to: GameServer.Client
   defdelegate get_status(pid), to: GameServer.Client
   defdelegate next(pid), to: GameServer.Client

--- a/lib/battle_snake/game_server/client.ex
+++ b/lib/battle_snake/game_server/client.ex
@@ -8,6 +8,10 @@ defmodule BattleSnake.GameServer.Client do
     GenServer.call(pid, :get_state)
   end
 
+  def get_game_state(pid) do
+    GenServer.call(pid, :get_game_state)
+  end
+
   def get_status(pid) do
     GenServer.call(pid, :get_status)
   end

--- a/lib/battle_snake/game_server/server.ex
+++ b/lib/battle_snake/game_server/server.ex
@@ -29,6 +29,10 @@ defmodule BattleSnake.GameServer.Server do
     |> do_reply
   end
 
+  def handle_call(:get_game_state, _from, state) do
+    {:reply, state, state}
+  end
+
   def handle_call(:get_status, _from, state) do
     {:reply, state.status, state}
   end
@@ -142,10 +146,13 @@ defmodule BattleSnake.GameServer.Server do
     reply
   end
 
+  def tick_event(state) do
+    %State.Event{name: :tick, data: state}
+  end
+
   def broadcast(state) do
     topic = state.game_form_id
-    event = %State.Event{name: :tick, data: state}
-    PubSub.broadcast(topic, event)
+    PubSub.broadcast(topic, tick_event(state))
     state
   end
 end

--- a/test/battle_snake/game_server/server_test.exs
+++ b/test/battle_snake/game_server/server_test.exs
@@ -36,4 +36,10 @@ defmodule BattleSnake.GameServer.ServerTest do
       assert {:ok, %State{}} == Server.init(%State{})
     end
   end
+
+  describe "Server.handle_call(:get_game_state, _, _)" do
+    test "returns the state" do
+      assert Server.handle_call(:get_game_state, self(), 1) == {:reply, 1, 1}
+    end
+  end
 end

--- a/test/channels/board_viewer_channel_test.exs
+++ b/test/channels/board_viewer_channel_test.exs
@@ -6,39 +6,37 @@ defmodule BattleSnake.BoardViewerChannelTest do
     GameServer
   }
 
-  setup [:sub]
+  setup [:sub, :broadcast_state]
 
   @tag content_type: "html"
   test "relays broadcasts to clients" do
-    broadcast_state()
     assert_broadcast "tick", %{content: _}
   end
 
   @tag content_type: "html"
   test "renders html" do
-    broadcast_state()
     assert_broadcast "tick", %{content: content}
     content =~ ~r/<svg>/
   end
 
   @tag content_type: "json"
   test "renders json" do
-    broadcast_state()
     assert_broadcast "tick", %{content: content}
     assert {:ok, _} = Poison.decode content
   end
 
+  def broadcast_state(c) do
+    state = build(:state)
+    GameServer.PubSub.broadcast(c.id, %GameServer.State.Event{name: "test", data: state})
+  end
+
   def sub c do
+    id = create(:game_form).id
     content_type = c.content_type
     {:ok, _, socket} =
       socket("user_id", %{})
-      |> subscribe_and_join(BoardViewerChannel, "board_viewer:1", %{"contentType" => content_type})
+      |> subscribe_and_join(BoardViewerChannel, "board_viewer:#{id}", %{"contentType" => content_type})
 
-    [socket: socket]
-  end
-
-  def broadcast_state() do
-    state = build(:state)
-    GameServer.PubSub.broadcast("1", %GameServer.State.Event{name: "test", data: state})
+    [socket: socket, id: id]
   end
 end


### PR DESCRIPTION
After joining the game the channel now pushes the game state to the client,
allowing the game to be rendered.

This way clients do not need to reset the game or wait for the next turn to
render the board.