### PR TITLE
Fix/bad move

### DIFF
--- a/lib/battle_snake/api.ex
+++ b/lib/battle_snake/api.ex
@@ -1,4 +1,6 @@
 defmodule BattleSnake.Api do
+  alias Ecto.Changeset
+
   alias BattleSnake.{
     Api.Response,
     GameForm,
@@ -10,8 +12,8 @@ defmodule BattleSnake.Api do
 
   require Logger
 
-  @load_whitelist ~w(color head_url name taunt)a
-  @move_whitelist ~w(move taunt)a
+  # @load_whitelist ~w(color head_url name taunt)a
+  # @move_whitelist ~w(move taunt)a
 
   @callback load(%SnakeForm{}, %GameForm{}) :: Response.t
   @callback move(%Snake{}, %World{}) :: Response.t
@@ -25,11 +27,11 @@ defmodule BattleSnake.Api do
   @spec load(%SnakeForm{}, %GameForm{}) :: Response.t
   def load(%{url: url}, data, request \\ &HTTP.post/4) do
     request_url = url <> "/start"
-    api_response = response(request_url, request, Snake, @load_whitelist, data)
+    api_response = response(request_url, request, data)
     update_in(api_response.parsed_response, fn
       {:ok, snake} ->
       (
-        snake = put_in(snake.url, url)
+        snake = put_in(snake["url"], url)
         {:ok, snake}
       )
       error ->
@@ -38,7 +40,32 @@ defmodule BattleSnake.Api do
         error
       )
     end)
+    |> do_load
   end
+
+  def do_load(response) do
+    update_in response.parsed_response, fn
+      {:ok, map} ->
+      (
+        {:ok, cast_load(map)}
+      )
+      response ->
+        response
+    end
+  end
+
+  def cast_load(map) do
+    data = %Snake{}
+    types = %{color: :string,
+              head_url: :string,
+              name: :string,
+              taunt: :string, url: :string}
+    {data, types}
+    |> Changeset.cast(map, Map.keys(types))
+    |> Changeset.validate_required([:name])
+    |> Changeset.apply_changes
+  end
+
 
   @doc """
   Get the move for a single snake.
@@ -48,21 +75,41 @@ defmodule BattleSnake.Api do
   @spec move(%Snake{}, %World{}) :: Response.t
   def move(%{url: url, id: id}, world, request \\ &HTTP.post/4) do
     data = Poison.encode!(world, me: id)
-    response(url <> "/move", request, Move, @move_whitelist, data)
+    (url <> "/move")
+    |> response(request, data)
+    |> do_move
   end
 
-  defp response(url, request, type, whitelist, data) do
-    st = struct(type)
+  def do_move(response) do
+    update_in response.parsed_response, fn
+      {:ok, map} ->
+      (
+        {:ok, cast_move(map)}
+      )
+      response ->
+        response
+    end
+  end
+
+  def cast_move(map) do
+    data = %Move{}
+    types = %{move: :string, taunt: :string}
+    {data, types}
+    |> Changeset.cast(map, Map.keys(types))
+    |> Changeset.validate_required([:move])
+    |> Changeset.validate_inclusion(:move, ~w(up down left right))
+    |> Changeset.apply_changes
+  end
+
+  defp response(url, request, data) do
     api_response = url
     |> request.(data, [], [])
-    |> Response.new(as: st)
+    |> Response.new(as: %{})
 
     update_in(api_response.parsed_response, fn
-      {:ok, snake} ->
+      {:ok, map} ->
       (
-        map = Map.take(snake, whitelist)
-        snake = struct(type, map)
-        {:ok, snake}
+        {:ok, map}
       )
       error ->
       (

--- a/lib/battle_snake/api/response.ex
+++ b/lib/battle_snake/api/response.ex
@@ -16,6 +16,7 @@ defmodule BattleSnake.Api.Response do
   """
 
   defstruct [
+    :url,
     raw_response: {:error, :init},
     parsed_response: {:error, :init}
   ]

--- a/lib/battle_snake/move.ex
+++ b/lib/battle_snake/move.ex
@@ -106,8 +106,11 @@ defmodule BattleSnake.Move do
     ]
   end
 
-  def direction_to_point(direction) do
-    case direction do
+  def to_point(%Move{move: move}),
+    do: to_point(move)
+
+  def to_point(move) when is_binary(move) do
+    case move do
       "up" -> up()
       "down" -> down()
       "left" -> left()

--- a/lib/battle_snake/move.ex
+++ b/lib/battle_snake/move.ex
@@ -1,6 +1,11 @@
 defmodule BattleSnake.Move do
   alias __MODULE__
-  alias BattleSnake.{World, Snake, Api.Response}
+  alias BattleSnake.{
+    World,
+    Point,
+    Snake,
+    Api.Response,
+  }
 
   defstruct [
     :move,
@@ -85,5 +90,28 @@ defmodule BattleSnake.Move do
 
   def response(move, response) do
     put_in move.__meta__.response, response
+  end
+
+  def up,     do: %Point{x: 0,  y: -1}
+  def down,   do: %Point{x: 0,  y: 1}
+  def right,  do: %Point{x: 1,  y: 0}
+  def left,   do: %Point{x: -1, y: 0}
+
+  def moves do
+    [
+      up(),
+      down(),
+      left(),
+      right(),
+    ]
+  end
+
+  def direction_to_point(direction) do
+    case direction do
+      "up" -> up()
+      "down" -> down()
+      "left" -> left()
+      "right" -> right()
+    end
   end
 end

--- a/lib/battle_snake/move.ex
+++ b/lib/battle_snake/move.ex
@@ -92,11 +92,16 @@ defmodule BattleSnake.Move do
     put_in move.__meta__.response, response
   end
 
-  def up,     do: %Point{x: 0,  y: -1}
-  def down,   do: %Point{x: 0,  y: 1}
-  def right,  do: %Point{x: 1,  y: 0}
-  def left,   do: %Point{x: -1, y: 0}
+  @spec up() :: Point.t
+  def up, do: %Point{x: 0, y: -1}
+  @spec down() :: Point.t
+  def down, do: %Point{x: 0, y: 1}
+  @spec right() :: Point.t
+  def right, do: %Point{x: 1, y: 0}
+  @spec left() :: Point.t
+  def left, do: %Point{x: -1, y: 0}
 
+  @spec moves() :: [Point.t]
   def moves do
     [
       up(),
@@ -106,9 +111,11 @@ defmodule BattleSnake.Move do
     ]
   end
 
+  @spec to_point(t) :: Point.t
   def to_point(%Move{move: move}),
     do: to_point(move)
 
+  @spec to_point(binary) :: Point.t
   def to_point(move) when is_binary(move) do
     case move do
       "up" -> up()

--- a/lib/battle_snake/world.ex
+++ b/lib/battle_snake/world.ex
@@ -54,29 +54,6 @@ defmodule BattleSnake.World do
          :deaths]
 
 
-  def up,     do: %Point{x: 0,  y: -1}
-  def down,   do: %Point{x: 0,  y: 1}
-  def right,  do: %Point{x: 1,  y: 0}
-  def left,   do: %Point{x: -1, y: 0}
-
-  def moves do
-    [
-      up(),
-      down(),
-      left(),
-      right(),
-    ]
-  end
-
-  def convert(direction) do
-    case direction do
-      "up" -> up()
-      "down" -> down()
-      "left" -> left()
-      "right" -> right()
-    end
-  end
-
   def stock_food(world) do
     f = fn (_i, world) ->
       add_food = & [rand_unoccupied_space(world) | &1]

--- a/lib/battle_snake/world_movement.ex
+++ b/lib/battle_snake/world_movement.ex
@@ -25,7 +25,7 @@ defmodule BattleSnake.WorldMovement do
     update_in(world.snakes, fn snakes ->
       for snake <- snakes do
         move = moves[snake.id]
-        point = Move.direction_to_point(move.move)
+        point = Move.to_point(move)
         Snake.move(snake, point)
       end
     end)

--- a/lib/battle_snake/world_movement.ex
+++ b/lib/battle_snake/world_movement.ex
@@ -25,7 +25,7 @@ defmodule BattleSnake.WorldMovement do
     update_in(world.snakes, fn snakes ->
       for snake <- snakes do
         move = moves[snake.id]
-        point = World.convert(move.move)
+        point = Move.direction_to_point(move.move)
         Snake.move(snake, point)
       end
     end)

--- a/test/battle_snake/api_test.exs
+++ b/test/battle_snake/api_test.exs
@@ -68,6 +68,26 @@ defmodule BattleSnake.ApiTest do
   end
 
   describe "Api.move/3" do
+    test "sets an error when the move is invalid" do
+      raw_response = %HTTPoison.Response{body: ~S({"move":"north"})}
+
+      mock = fn(@move_url, body, _, _) ->
+        send(self(), Poison.decode(body))
+        {:ok, raw_response}
+      end
+
+      move = Api.move(@snake, @world, mock)
+
+      assert %Api.Response{
+        url: "http://example.snake/move",
+        raw_response: {:ok, ^raw_response},
+        parsed_response: {:error, changeset}} = move
+
+      assert changeset.errors == [move: {"is invalid", []}]
+
+      assert_receive {:ok, %{"you" => "1234"}}
+    end
+
     test "on success responds with the move" do
       raw_response = %HTTPoison.Response{body: ~S({"move":"up"})}
 
@@ -79,6 +99,7 @@ defmodule BattleSnake.ApiTest do
       move = Api.move(@snake, @world, mock)
 
       assert move == %Api.Response{
+        url: "http://example.snake/move",
         raw_response: {
           :ok,
           raw_response},
@@ -101,6 +122,7 @@ defmodule BattleSnake.ApiTest do
       move = Api.move(@snake, @world, mock)
 
       assert move == %Api.Response{
+        url: "http://example.snake/move",
         raw_response: {
           :ok,
           raw_response},
@@ -117,6 +139,7 @@ defmodule BattleSnake.ApiTest do
       move = Api.move(@snake, @world, mock)
 
       assert move == %Api.Response{
+        url: "http://example.snake/move",
         raw_response: {
           :error,
           @http_error},

--- a/test/battle_snake/move_test.exs
+++ b/test/battle_snake/move_test.exs
@@ -4,7 +4,9 @@ defmodule BattleSnake.MoveTest  do
     Snake,
     Move,
     World,
-    Api.Response}
+    Point,
+    Api.Response,
+  }
 
   @green_snake %Snake{name: :green}
 
@@ -47,6 +49,13 @@ defmodule BattleSnake.MoveTest  do
       assert [%Move{} = move] = moves
       assert move.move == "up"
       assert {:ok, %Response{}} = move.__meta__.response
+    end
+  end
+
+  describe "Move.direction_to_point/1" do
+    test "converts direction strings to Points" do
+      assert %Point{x: 0, y: -1} ==
+        %Move{move: "up"}.move |> Move.direction_to_point
     end
   end
 end

--- a/test/battle_snake/move_test.exs
+++ b/test/battle_snake/move_test.exs
@@ -52,10 +52,10 @@ defmodule BattleSnake.MoveTest  do
     end
   end
 
-  describe "Move.direction_to_point/1" do
+  describe "Move.to_point/1" do
     test "converts direction strings to Points" do
       assert %Point{x: 0, y: -1} ==
-        %Move{move: "up"}.move |> Move.direction_to_point
+        %Move{move: "up"} |> Move.to_point
     end
   end
 end


### PR DESCRIPTION
Fixes an issue where the game would crash if a snake responded with a nonstandard move.

Now it will print debug level logging and just make the snake go up.

closes #9 

```
[info] JOIN game_admin:aeab10d7-adce-43af-b270-767a8775c2a8 to BattleSnake.GameAdminChannel
  Transport:  Phoenix.Transports.WebSocket
  Parameters: %{}
[info] Replied game_admin:aeab10d7-adce-43af-b270-767a8775c2a8 :ok
[debug] [localhost:4001/move] #Ecto.Changeset<action: nil, changes: %{move: "south", taunt: "south"}, errors: [move: {"is inva
lid", []}], data: #BattleSnake.Move<>, valid?: false> 
```
