### PR TITLE
Fix dead snake duplication

### DIFF
--- a/lib/battle_snake/api.ex
+++ b/lib/battle_snake/api.ex
@@ -27,6 +27,7 @@ defmodule BattleSnake.Api do
   @spec load(%SnakeForm{}, %GameForm{}) :: Response.t
   def load(%{url: url}, data, request \\ &HTTP.post/4) do
     request_url = url <> "/start"
+    data = Poison.encode!(data)
 
     api_response = request_url
     |> request.(data, [], [])
@@ -61,6 +62,7 @@ defmodule BattleSnake.Api do
     |> do_load
     |> do_log
   end
+
 
   def do_log(response) do
     with {:error, e} <- response.raw_response,

--- a/lib/battle_snake/api.ex
+++ b/lib/battle_snake/api.ex
@@ -12,9 +12,6 @@ defmodule BattleSnake.Api do
 
   require Logger
 
-  # @load_whitelist ~w(color head_url name taunt)a
-  # @move_whitelist ~w(move taunt)a
-
   @callback load(%SnakeForm{}, %GameForm{}) :: Response.t
   @callback move(%Snake{}, %World{}) :: Response.t
 

--- a/lib/battle_snake/api.ex
+++ b/lib/battle_snake/api.ex
@@ -25,12 +25,12 @@ defmodule BattleSnake.Api do
   POST /start
   """
   @spec load(%SnakeForm{}, %GameForm{}) :: Response.t
-  def load(%{url: url}, data, request \\ &HTTP.post/4) do
+  def load(%{url: url}, data, request \\ &HTTPoison.post/4) do
     request_url = url <> "/start"
     data = Poison.encode!(data)
 
     api_response = request_url
-    |> request.(data, [], [])
+    |> request.(data, ["content-type": "application/json"], [])
     |> Response.new(as: %{})
 
     api_response = put_in(api_response.url, url)
@@ -108,12 +108,12 @@ defmodule BattleSnake.Api do
   POST /move
   """
   @spec move(%Snake{}, %World{}) :: Response.t
-  def move(%{url: url, id: id}, world, request \\ &HTTP.post/4) do
+  def move(%{url: url, id: id}, world, request \\ &HTTPoison.post/4) do
     data = Poison.encode!(world, me: id)
     url = (url <> "/move")
 
     api_response = url
-    |> request.(data, [], [])
+    |> request.(data, ["content-type": "application/json"], [])
     |> Response.new(as: %{})
 
     api_response = put_in(api_response.url, url)

--- a/lib/battle_snake/api.ex
+++ b/lib/battle_snake/api.ex
@@ -44,7 +44,7 @@ defmodule BattleSnake.Api do
       )
     end)
 
-    update_in(api_response.parsed_response, fn
+    api_response = update_in(api_response.parsed_response, fn
       {:ok, snake} ->
       (
         snake = put_in(snake["url"], url)
@@ -56,8 +56,15 @@ defmodule BattleSnake.Api do
         error
       )
     end)
-    |> do_load
-    |> do_log
+
+    api_response = update_in api_response.parsed_response, fn
+      {:ok, map} ->
+        cast_load(map)
+      response ->
+        response
+    end
+
+    do_log(api_response)
   end
 
 
@@ -69,15 +76,6 @@ defmodule BattleSnake.Api do
       do: Logger.debug("[#{response.url}] #{inspect(e)}")
 
     response
-  end
-
-  def do_load(response) do
-    update_in response.parsed_response, fn
-      {:ok, map} ->
-        cast_load(map)
-      response ->
-        response
-    end
   end
 
   def cast_load(map) do
@@ -127,18 +125,14 @@ defmodule BattleSnake.Api do
       )
     end)
 
-    api_response
-    |> do_move
-    |> do_log
-  end
-
-  def do_move(response) do
-    update_in response.parsed_response, fn
+    api_response = update_in api_response.parsed_response, fn
       {:ok, map} ->
         cast_move(map)
       response ->
         response
     end
+
+    do_log(api_response)
   end
 
   def cast_move(map) do

--- a/lib/battle_snake/api.ex
+++ b/lib/battle_snake/api.ex
@@ -4,7 +4,6 @@ defmodule BattleSnake.Api do
   alias BattleSnake.{
     Api.Response,
     GameForm,
-    HTTP,
     Move,
     Snake,
     SnakeForm,
@@ -26,25 +25,25 @@ defmodule BattleSnake.Api do
     request_url = url <> "/start"
     data = Poison.encode!(data)
 
-    api_response = request_url
+    response = request_url
     |> request.(data, ["content-type": "application/json"], [])
     |> Response.new(as: %{})
 
-    api_response = put_in(api_response.url, url)
+    response = put_in(response.url, url)
 
-    update_in(api_response.parsed_response, fn
+    update_in(response.parsed_response, fn
       {:ok, map} ->
       (
         {:ok, map}
       )
       error ->
       (
-        log_error(url, error, api_response)
+        log_error(url, error, response)
         error
       )
     end)
 
-    api_response = update_in(api_response.parsed_response, fn
+    response = update_in(response.parsed_response, fn
       {:ok, snake} ->
       (
         snake = put_in(snake["url"], url)
@@ -52,21 +51,20 @@ defmodule BattleSnake.Api do
       )
       error ->
       (
-        log_error(request_url, error, api_response)
+        log_error(request_url, error, response)
         error
       )
     end)
 
-    api_response = update_in api_response.parsed_response, fn
+    response = update_in response.parsed_response, fn
       {:ok, map} ->
         cast_load(map)
       response ->
         response
     end
 
-    do_log(api_response)
+    do_log(response)
   end
-
 
   def do_log(response) do
     with {:error, e} <- response.raw_response,
@@ -107,32 +105,32 @@ defmodule BattleSnake.Api do
     data = Poison.encode!(world, me: id)
     url = (url <> "/move")
 
-    api_response = url
+    response = url
     |> request.(data, ["content-type": "application/json"], [])
     |> Response.new(as: %{})
 
-    api_response = put_in(api_response.url, url)
+    response = put_in(response.url, url)
 
-    update_in(api_response.parsed_response, fn
+    update_in(response.parsed_response, fn
       {:ok, map} ->
       (
         {:ok, map}
       )
       error ->
       (
-        log_error(url, error, api_response)
+        log_error(url, error, response)
         error
       )
     end)
 
-    api_response = update_in api_response.parsed_response, fn
+    response = update_in response.parsed_response, fn
       {:ok, map} ->
         cast_move(map)
       response ->
         response
     end
 
-    do_log(api_response)
+    do_log(response)
   end
 
   def cast_move(map) do
@@ -151,8 +149,8 @@ defmodule BattleSnake.Api do
     end
   end
 
-  defp log_error(url, error, api_response) do
-    http_response = inspect(api_response.raw_response, color: false, pretty: true)
+  defp log_error(url, error, response) do
+    http_response = inspect(response.raw_response, color: false, pretty: true)
     ("""
     Could not process API response for #{url}:
 

--- a/lib/battle_snake/game_form/reset.ex
+++ b/lib/battle_snake/game_form/reset.ex
@@ -17,8 +17,6 @@ defmodule BattleSnake.GameForm.Reset do
   Responsible for loading all snakes from the game's initial configuration.
   """
 
-  defmacrop load_fun(), do: quote do: &@api.load/2
-
   @spec init_world(GameForm.t) :: GameForm.t
   def init_world(game_form) do
     put_in(game_form.world,
@@ -80,7 +78,7 @@ defmodule BattleSnake.GameForm.Reset do
   Load all snakes from game_form.snakes into game_form.world
   """
   @spec load_snakes(GameForm.t, load_fun) :: GameForm.t
-  def load_snakes(game_form, load \\ load_fun()) do
+  def load_snakes(game_form, load \\ &@api.load/2) do
     task = fn(snake_form) ->
       snake_form
       |> health_check(game_form, load)
@@ -106,7 +104,7 @@ defmodule BattleSnake.GameForm.Reset do
   Reason for being unhealthy is kept in snake.healthy = {:error, reason}
   """
   @spec health_check(SnakeForm.t, GameForm.t, load_fun) :: SnakeForm.t
-  def health_check(snake_form, game_form, load \\ load_fun()) do
+  def health_check(snake_form, game_form, load \\ &@api.load/2) do
     response = load.(snake_form, game_form)
     with({:ok, snake} <- Api.Response.val(response)) do
       Snake.Health.ok(snake)

--- a/lib/battle_snake/http.ex
+++ b/lib/battle_snake/http.ex
@@ -1,7 +1,0 @@
-defmodule BattleSnake.HTTP do
-  use HTTPoison.Base
-
-  def process_request_headers(headers) do
-    put_in(headers, [:"content-type"], "application/json")
-  end
-end

--- a/lib/battle_snake/http.ex
+++ b/lib/battle_snake/http.ex
@@ -1,15 +1,6 @@
 defmodule BattleSnake.HTTP do
   use HTTPoison.Base
 
-  @spec process_request_body(struct) :: String.t
-  def process_request_body(struct) when is_map(struct) do
-    Poison.encode!(struct)
-  end
-
-  def process_request_body(body) when is_binary(body) do
-    body
-  end
-
   def process_request_headers(headers) do
     put_in(headers, [:"content-type"], "application/json")
   end

--- a/lib/battle_snake/mock_api.ex
+++ b/lib/battle_snake/mock_api.ex
@@ -3,19 +3,35 @@ defmodule BattleSnake.MockApi do
 
   def start, do: {:ok, [:fake]}
 
+  @snake {:ok, %HTTPoison.Response{body: Poison.encode!(%{name: "mock-snake"})}}
+  @move {:ok, %HTTPoison.Response{body: Poison.encode!(%{move: "up"})}}
+
   def load(x, y) do
-    BattleSnake.Api.load(x, y, fn _, _, _, _ ->
-      {:ok,
-       %HTTPoison.Response{
-         body: Poison.encode!(%{name: "mock-snake"})}}
-    end)
+    BattleSnake.Api.load(x, y, mock_post(@snake))
   end
 
   def move(x, y) do
-    BattleSnake.Api.move(x, y, fn _, _, _, _ ->
-      {:ok,
-       %HTTPoison.Response{
-         body: Poison.encode!(%{move: "up"})}}
-    end)
+    BattleSnake.Api.move(x, y, mock_post(@move))
+  end
+
+  def mock_post(return) do
+    fn
+      (url, body, headers, options)
+      when is_binary(url)
+      and is_binary(body)
+      and is_list(headers)
+      and is_list(options) -> return
+
+      (url, body, headers, options) ->
+        raise """
+        Expected mock_post(url:binary, body:binary, headers:keyword, options:keyword)
+
+        received:
+        url: #{inspect url, limit: 0}
+        body: #{inspect body, limit: 0}
+        headers: #{inspect headers, limit: 0}
+        options: #{inspect options, limit: 0}
+        """
+    end
   end
 end

--- a/lib/battle_snake/point.ex
+++ b/lib/battle_snake/point.ex
@@ -31,6 +31,11 @@ defmodule BattleSnake.Point do
       x: a.x + b.x,
     }
   end
+
+  def line(from, dir, length) do
+    Stream.iterate(from, &add(&1, dir))
+    |> Enum.take(length)
+  end
 end
 
 defimpl Poison.Encoder, for: BattleSnake.Point do

--- a/lib/battle_snake/snake.ex
+++ b/lib/battle_snake/snake.ex
@@ -16,10 +16,12 @@ defmodule BattleSnake.Snake do
     taunt: String.t,
     url: String.t,
     health: health,
+    cause_of_death: binary,
   }
 
   defstruct [
     :id,
+    :cause_of_death,
     color: "",
     coords: [],
     head_url: "",

--- a/lib/battle_snake/snake.ex
+++ b/lib/battle_snake/snake.ex
@@ -116,12 +116,8 @@ defmodule BattleSnake.Snake do
              # one or more are the same size
              # all die
              nil
-           [{_, snake} | victims] ->
-             growth = victims
-             |> Enum.map(& elem(&1, 0))
-             |> Enum.sum
-             growth = round(growth / 2)
-             grow(snake, growth)
+           [{_, snake} | _] ->
+             snake
          end
     end) |> Enum.reject(& &1 == nil)
   end

--- a/lib/battle_snake/world.ex
+++ b/lib/battle_snake/world.ex
@@ -106,6 +106,10 @@ defmodule BattleSnake.World do
     end
   end
 
+  @doc """
+  Move any snakes from .snakes that died this turn into .dead_snakes.
+  """
+  @spec clean_up_dead(t) :: t
   def clean_up_dead world do
     snakes = world.snakes
 

--- a/test/battle_snake/snake_test.exs
+++ b/test/battle_snake/snake_test.exs
@@ -1,8 +1,14 @@
 defmodule BattleSnake.SnakeTest do
-  alias BattleSnake.{World, Snake, Point}
+  alias BattleSnake.{
+    World,
+    Snake,
+    Point
+  }
 
   use BattleSnake.Case, async: true
   use Property
+  use Point
+  import Point
 
   @world %World{width: 10, height: 10}
 
@@ -24,7 +30,7 @@ defmodule BattleSnake.SnakeTest do
     end)
   end
 
-  describe "#dead?" do
+  describe "Snake.dead?" do
     test "detects body collisions" do
       world = %World{width: 10, height: 10}
       coords = [
@@ -105,22 +111,13 @@ defmodule BattleSnake.SnakeTest do
       assert Snake.resolve_head_to_head(snakes) == []
     end
 
-    test "kills the smaller snakes, and grows the victor" do
-      snakes = [
-        %Snake{coords: [%Point{y: 5, x: 5}, %Point{y: 5, x: 4},]},
-        %Snake{coords: [%Point{y: 5, x: 5}, %Point{y: 4, x: 5}, %Point{y: 3, x: 5},]},
-      ]
+    test "kills smaller snakes" do
+      small_snake = build(:snake, id: :small, coords: [p(0, 0)])
+      big_snake = build(:snake, id: :big, coords: [p(0, 0), p(1, 0)])
 
-      assert(Snake.resolve_head_to_head(snakes) == [
-        %Snake{
-          coords: [
-            %Point{y: 5, x: 5},
-            %Point{y: 4, x: 5},
-            %Point{y: 3, x: 5},
-            %Point{y: 3, x: 5}
-          ]
-        }
-      ])
+      snakes = [small_snake, big_snake]
+
+      assert(Snake.resolve_head_to_head(snakes) == [big_snake])
     end
 
     test "does nothing to nonoverlapping snakes" do

--- a/test/battle_snake/world_test.exs
+++ b/test/battle_snake/world_test.exs
@@ -6,7 +6,8 @@ defmodule BattleSnake.WorldTest do
   }
   use BattleSnake.Case, async: true
   use Property
-  use BattleSnake.Point
+  use Point
+  import Point
 
   setup context do
     world = %World{
@@ -107,17 +108,33 @@ defmodule BattleSnake.WorldTest do
     end
   end
 
-  describe "#clean_up_dead" do
-    test "removes any snakes that die in head to heads", %{world: world} do
-      snake = %Snake{coords: [%Point{y: 5, x: 5}]}
-
-      world = put_in world.snakes, [snake, snake]
+  describe "World.clean_up_dead/1 head to head collision" do
+    test "kills same length snakes" do
+      big_snake = (build :snake, id: :big, coords: line(p(0,0), p(0, 1), 3))
+      small_snake = (build :snake, id: :small, coords: line(p(0,0), p(1, 0), 3))
+      world = build(:world, width: 100, height: 100, snakes: [big_snake, small_snake])
 
       world = World.clean_up_dead(world)
+
       assert world.snakes == []
-      assert world.dead_snakes == [snake, snake]
+      assert small_snake in world.dead_snakes
+      assert big_snake in world.dead_snakes
+      assert 2 == length world.dead_snakes
     end
 
+    test "kills the smaller snake" do
+      big_snake = (build :snake, id: :big, coords: line(p(0,0), p(0, 1), 10))
+      small_snake = (build :snake, id: :small, coords: line(p(0,0), p(1, 0), 3))
+      world = build(:world, width: 100, height: 100, snakes: [big_snake, small_snake])
+
+      world = World.clean_up_dead(world)
+
+      assert world.snakes == [big_snake]
+      assert world.dead_snakes == [small_snake]
+    end
+  end
+
+  describe "World.clean_up_dead/1" do
     test "removes snakes that died in body collisions", %{world: world} do
       snake = %Snake{coords: [%Point{y: 5, x: 5}, %Point{y: 5, x: 5}]}
       world = put_in world.snakes, [snake]


### PR DESCRIPTION
This corrects an issue where, in the event of a head on collision, the winning snake would be copied in to
the list of dead snakes along with its _victims_.

Snakes that win head on collisions are no longer copied across to the dead snake list.

In addition this removes the rule where snakes would grow by half of their victims length in head on collisions.

This pr also includes some general clean up around the api module.