### PR TITLE
Fix/food restock

### DIFF
--- a/lib/battle_snake/game_form/reset.ex
+++ b/lib/battle_snake/game_form/reset.ex
@@ -121,9 +121,8 @@ defmodule BattleSnake.GameForm.Reset do
 
   @spec new_coords(World.t) :: World.t
   def new_coords(world) do
-    world
-    |> World.rand_unoccupied_space()
-    |> List.duplicate(@new_snake_length)
+    {:ok, point} = World.rand_unoccupied_space(world)
+    List.duplicate(point, @new_snake_length)
   end
 
   @spec set_url(Snake.t, SnakeForm.t) :: Snake.t

--- a/lib/battle_snake/world.ex
+++ b/lib/battle_snake/world.ex
@@ -56,8 +56,10 @@ defmodule BattleSnake.World do
 
   def stock_food(world) do
     f = fn (_i, world) ->
-      add_food = & [rand_unoccupied_space(world) | &1]
-      update_in(world.food, add_food)
+      update_in(world.food, fn food ->
+        {:ok, point} = rand_unoccupied_space(world)
+        [point | food]
+      end)
     end
 
     n = world.max_food - length(world.food)
@@ -66,7 +68,7 @@ defmodule BattleSnake.World do
     |> Enum.reduce(world, f)
   end
 
-  # @spec rand_unoccupied_space(t) :: any
+  @spec rand_unoccupied_space(t) :: {:ok, Point.t} | {:error, any}
   def rand_unoccupied_space(world) do
     h = world.height - 1
     w = world.width - 1
@@ -78,7 +80,7 @@ defmodule BattleSnake.World do
       not %Point{y: y, x: x} in food,
       do: %Point{y: y, x: x}
 
-    Enum.random open_spaces
+    {:ok, Enum.random(open_spaces)}
   end
 
   @doc "increase world.turn by 1"

--- a/lib/battle_snake/world.ex
+++ b/lib/battle_snake/world.ex
@@ -54,20 +54,32 @@ defmodule BattleSnake.World do
          :deaths]
 
 
+  @doc """
+  Restock food on the board.
+  """
+  @spec stock_food(t) :: t
   def stock_food(world) do
-    f = fn (_i, world) ->
-      update_in(world.food, fn food ->
-        case rand_unoccupied_space(world) do
-          {:ok, point} -> [point | food]
-          _ -> food
-        end
-      end)
-    end
+    i = world.max_food - length(world.food)
+    i = max(i, 0)
+    do_stock_food(i, world)
+  end
 
-    n = world.max_food - length(world.food)
+  defp do_stock_food(0, world) do
+    world
+  end
 
-    times(n)
-    |> Enum.reduce(world, f)
+  defp do_stock_food(i, world) do
+    point = rand_unoccupied_space(world)
+    do_stock_food(point, i, world)
+  end
+
+  defp do_stock_food({:ok, point}, i, world) do
+    world = update_in(world.food, &([point|&1]))
+    do_stock_food(i-1, world)
+  end
+
+  defp do_stock_food({:error, _}, _, world) do
+    world
   end
 
   @spec rand_unoccupied_space(t) :: {:ok, Point.t} | {:error, any}

--- a/test/battle_snake/world_test.exs
+++ b/test/battle_snake/world_test.exs
@@ -67,10 +67,10 @@ defmodule BattleSnake.WorldTest do
     end
   end
 
-  describe "#rand_unoccupied_space" do
+  describe "World.rand_unoccupied_space/1" do
     property "in the bounds of the board, on an unoccupied space" do
       forall world(), fn w ->
-        point = World.rand_unoccupied_space(w)
+        {:ok, point} = World.rand_unoccupied_space(w)
 
         coords = Enum.flat_map w.snakes, &(&1.coords)
 
@@ -82,10 +82,15 @@ defmodule BattleSnake.WorldTest do
     end
   end
 
-  describe "#stock_food" do
+  describe "World.stock_food/1" do
     test "sets food on the board, up to a max", %{world: world} do
       world = World.stock_food(world)
       assert length(world.food) == 4
+    end
+
+    test "does nothing if there is no space" do
+      world = build(:world, width: 1, height: 1)
+      assert World.stock_food(world) == world
     end
 
     test "sets no food if set to 0", %{world: world} do

--- a/test/battle_snake/world_test.exs
+++ b/test/battle_snake/world_test.exs
@@ -80,6 +80,11 @@ defmodule BattleSnake.WorldTest do
           point.y in World.rows(w))
       end
     end
+
+    test "returns an error if there is no space" do
+      world = build(:world, width: 1, height: 1, food: [p(0, 0)])
+      assert {:error, :empty_error} == World.rand_unoccupied_space(world)
+    end
   end
 
   describe "World.stock_food/1" do
@@ -89,7 +94,7 @@ defmodule BattleSnake.WorldTest do
     end
 
     test "does nothing if there is no space" do
-      world = build(:world, width: 1, height: 1)
+      world = build(:world, width: 1, height: 1, food: [p(0, 0)])
       assert World.stock_food(world) == world
     end
 

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -44,7 +44,7 @@ defmodule BattleSnake.Factory do
   end
 
   def with_snake_in_world(snake: snake, world: world, length: length) do
-    point = BattleSnake.World.rand_unoccupied_space(world)
+    {:ok, point} = BattleSnake.World.rand_unoccupied_space(world)
     snake = put_in(snake.coords, List.duplicate(point, length))
     world = update_in(world.snakes, & [snake|&1])
     [snake: snake, world: world]


### PR DESCRIPTION
Fixes the bug where attempting to add more food when there was no more room would crash the game.
