### PR TITLE
Add mix setup alias

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -15,6 +15,7 @@ defmodule BattleSnake.Mixfile do
      test_coverage: [tool: ExCoveralls],
      erlc_options: erlc_options(Mix.env),
      dialyzer: dialyzer(),
+     aliases: aliases(),
      deps: deps()]
   end
 
@@ -89,5 +90,27 @@ defmodule BattleSnake.Mixfile do
        "-Werror_handling",
        "-Wrace_conditions",
        "-Wunderspecs"]]
+  end
+
+  defp aliases do
+     [setup: [&check_prereqs/1, &npm_install/1, "deps.get", "compile", "battle_snake.schema", &test/1]]
+  end
+
+  defp npm_install(_) do
+    Mix.shell.cmd("npm install")
+  end
+
+  def test(_) do
+    Mix.shell.cmd("MIX_ENV=test mix test")
+  end
+
+  def check_prereqs(_) do
+    prereq("sass")
+    prereq("npm")
+  end
+
+  def prereq(cmd) do
+    if Mix.shell.cmd("command -v #{cmd} >/dev/null 2>&1") != 0,
+      do: Mix.raise("#{cmd} is required, but could not be found. Aborting.")
   end
 end


### PR DESCRIPTION
mix setup will do everything that is required to get someone running the project
locally.

It will also check for dependencies.

ex.

    ~/src/battle_snake/ (master ✗) ❱ mix setup
    ** (Mix) sass is required, but could not be found. Aborting.
    ~/src/battle_snake/ (master ✗) ❱ gem install sass
    Fetching: sass-3.4.23.gem (100%)
    Successfully installed sass-3.4.23
    Parsing documentation for sass-3.4.23
    Installing ri documentation for sass-3.4.23
    Done installing documentation for sass after 2 seconds
    1 gem installed
    ~/src/battle_snake/ (master ✗) ❱
    ~/src/battle_snake/ (master ✗) ❱ mix setup
    npm WARN optional SKIPPING OPTIONAL DEPENDENCY: fsevents@^1.0.0 (node_modules/brunch/node_modules/chokidar/node_modules/fsevents):
    npm WARN notsup SKIPPING OPTIONAL DEPENDENCY: Unsupported platform for fsevents@1.0.17: wanted {"os":"darwin","arch":"any"} (current: {"os":"linux","arch":"x64"})
    Running dependency resolution...
    All dependencies up to date
    Mnesia(nonode@nohost): ...
    .................................................................................................................................................

    Finished in 0.6 seconds
    3 properties, 143 tests, 0 failures, 1 skipped

    Randomized with seed 605931