### PR TITLE
Optimize/board viewer speedup

### DIFF
--- a/web/channels/board_viewer_channel.ex
+++ b/web/channels/board_viewer_channel.ex
@@ -47,7 +47,10 @@ defmodule BattleSnake.BoardViewerChannel do
   end
 
   defp render_content(_, state) do
-    Phoenix.View.render_to_string(BattleSnake.BoardViewerView, "board.html", state: state)
+    BattleSnake.BoardViewerView
+    |> Phoenix.View.render_to_string("board.html", state: state)
+    |> String.replace(~r/^\s+|\s+$/m, "")
+    |> String.replace(~r/\n+/m, " ")
   end
 
   defp set_content_type(socket, payload) do

--- a/web/static/js/app.js
+++ b/web/static/js/app.js
@@ -1,60 +1,11 @@
-// Brunch automatically concatenates all files in your
-// watched paths. Those paths can be configured at
-// config.paths.watched in "brunch-config.js".
-//
-// However, those files will only be executed if
-// explicitly imported. The only exception are files
-// in vendor, which are never wrapped in imports and
-// therefore are always executed.
-
-// Import dependencies
-//
-// If you no longer want to use a dependency, remember
-// to also remove its path from "config.paths.watched".
 import "phoenix_html"
-// Import local files
-//
-// Local files can be imported directly using relative
-// paths "./socket" or full ones "web/static/js/socket".
-import socket from "./socket"
 import $ from "jquery";
-import Mousetrap from "mousetrap";
-import "./empties/modal";
+import * as BS from "./battle_snake"
 
-const gameId = window.BattleSnake.gameId;
-const logError = resp => { console.error("Unable to join", resp) };
+const BattleSnake = Object.assign(window.BattleSnake, BS);
+window.BattleSnake = BattleSnake;
 
-const init = () => {
-  const boardViewerChannel = socket.channel(`board_viewer:${gameId}`, {contentType: "html"});
-  const gameAdminChannel = socket.channel(`game_admin:${gameId}`);
-
-  boardViewerChannel.on("tick", ({content}) => {
-    $("#board-viewer").html(content);
-  });
-
-  boardViewerChannel.
-    join().
-    receive("error", logError);
-
-  gameAdminChannel.
-    join().
-    receive("error", logError);
-
-  const cmd = (request) => {
-    console.log(request);
-    gameAdminChannel.
-      push(request).
-      receive("error", e => console.error(`push "${request}" failed`, e));
-  };
-
-  Mousetrap.bind(["q"], () => cmd("stop"));
-  Mousetrap.bind(["h", "left"], () => cmd("prev"));
-  Mousetrap.bind(["j", "up"], () => cmd("resume"));
-  Mousetrap.bind(["k", "down"], () => cmd("pause"));
-  Mousetrap.bind(["l", "right"], () => cmd("next"));
-  Mousetrap.bind("R", () => cmd("replay"));
-}
-
-if(typeof gameId !== "undefined") {
-  init();
+if ($("#board-viewer")) {
+  const gameId = window.BattleSnake.gameId;
+  window.BattleSnake.BoardViewer.init(gameId);
 }

--- a/web/static/js/battle_snake/board_viewer.js
+++ b/web/static/js/battle_snake/board_viewer.js
@@ -1,0 +1,47 @@
+import Mousetrap from "mousetrap";
+import $ from "jquery";
+import socket from "../socket"
+import "../empties/modal";
+
+const logError = resp => {
+  console.error("Unable to join", resp)
+};
+
+const init = (gameId) => {
+  if(typeof gameId === "undefined") {
+    return;
+  }
+
+  const boardViewerChannel = socket.channel(`board_viewer:${gameId}`, {contentType: "html"});
+  const gameAdminChannel = socket.channel(`game_admin:${gameId}`);
+
+  boardViewerChannel.on("tick", ({content}) => {
+    $("#board-viewer").html()
+  });
+
+  boardViewerChannel.
+    join().
+    receive("error", logError);
+
+  gameAdminChannel.
+    join().
+    receive("error", logError);
+
+  const cmd = (request) => {
+    console.log(request);
+    gameAdminChannel.
+      push(request).
+      receive("error", e => console.error(`push "${request}" failed`, e));
+  };
+
+  Mousetrap.bind(["q"], () => cmd("stop"));
+  Mousetrap.bind(["h", "left"], () => cmd("prev"));
+  Mousetrap.bind(["j", "up"], () => cmd("resume"));
+  Mousetrap.bind(["k", "down"], () => cmd("pause"));
+  Mousetrap.bind(["l", "right"], () => cmd("next"));
+  Mousetrap.bind("R", () => cmd("replay"));
+};
+
+export default {
+  init
+};

--- a/web/static/js/battle_snake/board_viewer.js
+++ b/web/static/js/battle_snake/board_viewer.js
@@ -1,5 +1,4 @@
 import Mousetrap from "mousetrap";
-import $ from "jquery";
 import socket from "../socket"
 import "../empties/modal";
 
@@ -16,7 +15,7 @@ const init = (gameId) => {
   const gameAdminChannel = socket.channel(`game_admin:${gameId}`);
 
   boardViewerChannel.on("tick", ({content}) => {
-    $("#board-viewer").html()
+    document.getElementById("board-viewer").innerHTML = content;
   });
 
   boardViewerChannel.

--- a/web/static/js/battle_snake/index.js
+++ b/web/static/js/battle_snake/index.js
@@ -1,0 +1,1 @@
+export {default as BoardViewer} from "./board_viewer";

--- a/web/templates/play/show.html.eex
+++ b/web/templates/play/show.html.eex
@@ -1,3 +1,2 @@
 <%= render "_modal_keybinds.html" %>
 <div id="board-viewer" class="play-show"></div>
-<%= link "Finals View", to: skin_path(@conn, :show, @game), class: "btn btn-default btn-xs view-btn" %>


### PR DESCRIPTION
Optimize dom replacement for board viewer

Switches from using `$(...).html(...)` to `document.getElementById(...).innerHTML = ...`.

This one line cuts down the "loading" slice from the chrome timeline from 25% to
3%. jQuery.html performs a very expensive html validation before inserting to
into the dom.

Because we *hope* that we're sending valid html before hand we don't need to do
this.

This leaves page redraw and paint as the next largest bottleneck, which cannot
be overcome without using something other than svg.

Minify html content over websockets
removes all leading or trailing whitespace, truncates all newlines resulting in
1/5 reduction in payload size for most games.
