### PR TITLE
Add test snake controller

### DIFF
--- a/web/controllers/test/example_controller.ex
+++ b/web/controllers/test/example_controller.ex
@@ -1,0 +1,11 @@
+defmodule BattleSnake.Test.ExampleController do
+  use BattleSnake.Web, :controller
+
+  def start(conn, _params) do
+    render(conn, "start.json")
+  end
+
+  def move(conn, _params) do
+    render(conn, "move.json")
+  end
+end

--- a/web/router.ex
+++ b/web/router.ex
@@ -22,6 +22,15 @@ defmodule BattleSnake.Router do
     resources "/skin", SkinController, only: [:show]
   end
 
+  scope "/test", BattleSnake.Test, as: :test do
+    pipe_through :api
+
+    get "/example/start", ExampleController, :start
+    get "/example/move", ExampleController, :move
+    post "/example/start", ExampleController, :start
+    post "/example/move", ExampleController, :move
+  end
+
   scope "/api", BattleSnake.Api, as: :api do
     pipe_through :api
 

--- a/web/views/test/example_view.ex
+++ b/web/views/test/example_view.ex
@@ -1,0 +1,17 @@
+defmodule BattleSnake.Test.ExampleView do
+  use BattleSnake.Web, :view
+
+  def render("move.json", _assigns) do
+    %{
+      move: "down",
+    }
+  end
+
+  def render("start.json", _assigns) do
+    %{
+      name: "BattleSnake Example Snake",
+      color: "#ffffff",
+      head_url: "http://placecage.com/c/300/300"
+    }
+  end
+end


### PR DESCRIPTION
Adds an example snake hosted on the server.

This snake can be added to games for demo purposes.

![1487969070](https://cloud.githubusercontent.com/assets/3162299/23320310/0792c538-fa8f-11e6-9bfa-47127b7b33c6.png)
