### PR TITLE
Fix turn speed

### DIFF
--- a/lib/battle_snake/game_server/server.ex
+++ b/lib/battle_snake/game_server/server.ex
@@ -6,8 +6,15 @@ defmodule BattleSnake.GameServer.Server do
   import State
   use GenServer
 
-  def init({:ok, value}), do: init(value)
-  def init({:error, reason}), do: {:stop, reason}
+  ########
+  # Init #
+  ########
+
+  def init({:ok, value}),
+    do: init(value)
+
+  def init({:error, reason}),
+    do: {:stop, reason}
 
   def init(game_form_id) when is_binary(game_form_id) do
     GameForm
@@ -22,138 +29,182 @@ defmodule BattleSnake.GameServer.Server do
   end
 
   def init(%State{} = state) do
-    state
-    |> State.on_start
-
-    {:ok, state}
-    |> do_reply
+    state = State.on_start(state)
+    do_reply({:ok, state})
   end
+
+  #########################
+  # Handle Call Callbacks #
+  #########################
+
+  ##################
+  # Get Game State #
+  ##################
 
   @spec handle_call(:get_game_state, pid, State.t) :: {:reply, State.t, State.t}
   def handle_call(:get_game_state, _from, state) do
     {:reply, state, state}
   end
 
+  ##############
+  # Get Status #
+  ##############
+
   def handle_call(:get_status, _from, state) do
     {:reply, state.status, state}
   end
 
-  def handle_call(:next, _from, state) do
-    case state.status do
-      :halted ->
-        {:reply, :ok, state}
+  ########
+  # Next #
+  ########
 
-      _ ->
-        state = State.step(state)
-        {:reply, :ok, State.suspend!(state)}
-    end
-    |> do_reply
+  def handle_call(:next, _from, state) do
+    state =
+      case state.status do
+        :halted ->
+          state
+
+        _status ->
+          state
+          |> State.step
+          |> State.suspend!
+      end
+
+    do_reply({:reply, :ok, state})
   end
 
   def handle_call(:pause, _from, state) do
-    case state.status do
-      :cont ->
-        {:reply, :ok, suspend!(state)}
+    state =
+      case state.status do
+        :cont ->
+          suspend!(state)
+        _status ->
+          state
+      end
 
-      _status ->
-        {:reply, :ok, state}
-    end
-    |> do_reply
+    do_reply({:reply, :ok, state})
   end
+
+  ########
+  # Prev #
+  ########
 
   def handle_call(:prev, _from, state) do
-    case state.status do
-      _status ->
-        state = state
-        |> State.step_back()
-        {:reply, :ok, suspend!(state)}
-    end
-    |> do_reply
+    state = state
+    |> State.step_back
+    |> suspend!
+
+    do_reply({:reply, :ok, state})
   end
+
+  ##########
+  # Resume #
+  ##########
 
   def handle_call(:resume, _from, state) do
-    case state.status do
-      :suspend ->
-        tick(state)
-        {:reply, :ok, cont!(state)}
+    state =
+      case state.status do
+        :suspend ->
+          send(self(), :tick)
+          cont!(state)
 
-      _status ->
-        {:reply, :ok, state}
-    end
-    |> do_reply
+        _status ->
+          state
+      end
+
+    do_reply({:reply, :ok, state})
   end
 
+  ##########
+  # Replay #
+  ##########
+
   def handle_call(:replay, _from, state) do
-    state = load_history(state)
-    tick(state)
-    {:reply, :ok, replay!(state)}
-    |> do_reply
+    send(self(), :tick)
+    state = state
+    |> load_history
+    |> replay!
+    do_reply({:reply, :ok, state})
   end
 
   def handle_call(request, from, state) do
-    # Call the default implementation from GenServer
     super(request, from, state)
   end
+
+  #########################
+  # Handle Cast Callbacks #
+  #########################
 
   def handle_cast(request, state) do
     super(request, state)
   end
 
+  #########################
+  # Handle Info Callbacks #
+  #########################
+
+  #############
+  # Get State #
+  #############
+
   def handle_info(:get_state, state) do
     {:reply, state, state.status}
   end
 
+  ########
+  # Tick #
+  ########
+
   def handle_info(:tick, state) do
-    case state.status do
-      :cont ->
-        state = State.step(state)
-        if State.done?(state) do
-          state = State.on_done(state)
-          {:noreply, halted!(state)}
-        else
-          tick(state)
-          {:noreply, cont!(state)}
-        end
-
-      :replay ->
-        state= State.step(state)
-        tick(state)
-        {:noreply, state}
-
-      :halted ->
-        {:noreply, state}
-
-      :suspend ->
-        {:noreply, state}
-    end
-    |> do_reply
+    state =
+      case state.status do
+        :cont -> tick_cont(state)
+        :replay -> State.step(state)
+        _ -> state
+      end
+    do_reply({:noreply, state})
   end
 
   def handle_info(request, state) do
     super(request, state)
   end
 
-  defp tick(state) do
-    Process.send_after(self(), :tick, State.delay(state))
+  ###################
+  # Private Methods #
+  ###################
+
+  defp tick_cont(state) do
+    delay = State.delay(state)
+
+    Process.send_after(self(), :tick, delay)
+
+    state = State.step(state)
+
+    if State.done?(state) do
+      state = State.on_done(state)
+      halted!(state)
+    else
+      cont!(state)
+    end
   end
 
-  def do_reply({_, state} = reply) do
-    broadcast(state)
-    reply
-  end
-
-  def do_reply({_, _, state} = reply) do
-    broadcast(state)
-    reply
-  end
-
-  def tick_event(state) do
-    %State.Event{name: :tick, data: state}
-  end
-
-  def broadcast(state) do
+  defp broadcast(state) do
     topic = state.game_form_id
     PubSub.broadcast(topic, tick_event(state))
     state
+  end
+
+  defp tick_event(state) do
+    %State.Event{name: :tick, data: state}
+  end
+
+  defp do_reply({_, state} = reply) do
+    broadcast(state)
+    reply
+  end
+
+  defp do_reply({_, _, state} = reply) do
+    broadcast(state)
+    reply
   end
 end

--- a/test/battle_snake/game_server/server_test.exs
+++ b/test/battle_snake/game_server/server_test.exs
@@ -1,7 +1,7 @@
 defmodule BattleSnake.GameServer.ServerTest do
   alias BattleSnake.GameServer.Server
   alias BattleSnake.GameServer.State
-  use BattleSnake.Case, async: true
+  use BattleSnake.Case, async: false
 
   def create_game_form(_) do
     [game_form: create(:game_form)]
@@ -40,6 +40,28 @@ defmodule BattleSnake.GameServer.ServerTest do
   describe "Server.handle_call(:get_game_state, _, _)" do
     test "returns the state" do
       assert Server.handle_call(:get_game_state, self(), 1) == {:reply, 1, 1}
+    end
+  end
+
+  describe "Server.handle_info(:tick, state) when state.status is cont" do
+    test "sends a :tick message after the confiured delay as a lower bound" do
+      objective = fn _ -> false end
+      state = build(:state, status: :cont, delay: 2, objective: objective)
+
+      Server.handle_info(:tick, state)
+      assert_receive :tick, 10
+    end
+
+    test "sends a :tick message after execution as an upper bound" do
+      objective = fn _ ->
+        Process.sleep(2)
+        false
+      end
+
+      state = build(:state, status: :cont, delay: 0, objective: objective)
+
+      Server.handle_info(:tick, state)
+      assert_receive :tick, 10
     end
   end
 end


### PR DESCRIPTION
Previously turn delay was additive to the wall clock on handle_info :tick

this makes it act as a lower bound.

e.g
delay := 100
wall clock on handle_info :tick := 200
next tick would be 300 after the start of the last tick

delay := 300
wall clock on handle_info :tick := 200
next tick would be 500 after the start of the last tick

After change

delay := 100
wall clock on handle_info :tick := 200
next tick would be 200 after the start of the last tick

delay := 300
wall clock on handle_info :tick := 200
next tick would be 300 after the start of the last tick