### PR TITLE
Move apt-get dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 FROM elixir:1.4.1
 WORKDIR /app
-ADD . .
 RUN apt-get update
 RUN apt-get install -y npm nodejs nodejs-legacy inotify-tools ruby
+ADD . .
 RUN mix local.hex --force
 RUN mix deps.get
 RUN gem install sass


### PR DESCRIPTION
Moving apt-get dependencies above the add statement means that you don't have to re-get the dependencies every time you update the code
Makes the build process slightly faster.