### PR TITLE
Setup script

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,14 +32,13 @@ The 2017 Game Server
 ```sh
 git clone git@github.com:StemboltHQ/battle_snake.git`
 cd battle_snake
-mix setup
+./scripts/setup
 ./scripts/dev-server
 ```
 
 ## Testing
 
 ```sh
-mix setup # only required the first time
 mix test
 ```
 

--- a/scripts/setup
+++ b/scripts/setup
@@ -1,0 +1,2 @@
+#!/bin/bash
+elixir --sname battle-snake-dev@localhost -S mix setup


### PR DESCRIPTION
The old setup instruction didn't work with the dev sever script because it didn't create a schema for the same node.