### PR TITLE
Blow away previous winners on save

### DIFF
--- a/lib/battle_snake/game_result_snake.ex
+++ b/lib/battle_snake/game_result_snake.ex
@@ -2,6 +2,8 @@ defmodule BattleSnake.GameResultSnake do
   alias __MODULE__
   require Record
 
+  @enforce_keys [:id]
+
   @encoded_fields [
     :created_at,
     :game_id,

--- a/lib/mnesia/repo.ex
+++ b/lib/mnesia/repo.ex
@@ -18,6 +18,8 @@ defmodule Mnesia do
   defdelegate create_schema(nodes), to: :mnesia
   defdelegate delete_schema(nodes), to: :mnesia
   defdelegate delete_table(tab), to: :mnesia
+  defdelegate delete(tab_key), to: :mnesia
+  defdelegate delete(tab, key, lock_kind), to: :mnesia
   defdelegate dirty_index_read(tab, secondary_key, pos), to: :mnesia
   defdelegate dirty_read(table, id), to: :mnesia
   defdelegate dirty_select(table, spec), to: :mnesia


### PR DESCRIPTION
Previously when the winners for a game were saved the records
just got added to the existing list. This makes it so that all previous winners
get blown away when it's saved again.